### PR TITLE
Fix PutRolePolicy Error

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -122,8 +122,7 @@ ROLE_ARN=$(
     --query 'Role.Arn'
 )
 
-USER_ID=$(aws iam get-user --query 'User.UserId')
-AWS_ID=$(aws sts get-caller-identity --query Account --output text)
+AWS_ID=$(aws sts get-caller-identity --query Account)
 
 aws iam put-role-policy \
   --role-name "$PROJECT_NAME" \

--- a/deploy.sh
+++ b/deploy.sh
@@ -123,6 +123,7 @@ ROLE_ARN=$(
 )
 
 USER_ID=$(aws iam get-user --query 'User.UserId')
+AWS_ID=$(aws sts get-caller-identity --query Account --output text)
 
 aws iam put-role-policy \
   --role-name "$PROJECT_NAME" \
@@ -135,7 +136,7 @@ aws iam put-role-policy \
       "Sid": "LogGroup",
       "Effect": "Allow",
       "Action": "logs:CreateLogGroup",
-      "Resource": "arn:aws:logs:'"$AWS_REGION"':'"$USER_ID"':log-group:*"
+      "Resource": "arn:aws:logs:'"$AWS_REGION"':'"$AWS_ID"':log-group:*"
     },
     {
       "Sid": "LogStream",
@@ -144,7 +145,7 @@ aws iam put-role-policy \
         "logs:CreateLogStream",
         "logs:PutLogEvents"
       ],
-      "Resource": "arn:aws:logs:'"$AWS_REGION"':'"$USER_ID"':log-group:/aws/lambda/'"$PROJECT_NAME"':*"
+      "Resource": "arn:aws:logs:'"$AWS_REGION"':'"$AWS_ID"':log-group:/aws/lambda/'"$PROJECT_NAME"':*"
     },
     {
       "Sid": "LambdaFunction",
@@ -154,7 +155,7 @@ aws iam put-role-policy \
         "lambda:UpdateFunctionConfiguration",
         "lambda:GetFunctionConfiguration"
       ],
-      "Resource": "arn:aws:lambda:'"$AWS_REGION"':'"$USER_ID"':function:'"$PROJECT_NAME"'"
+      "Resource": "arn:aws:lambda:'"$AWS_REGION"':'"$AWS_ID"':function:'"$PROJECT_NAME"'"
     }
   ]
 }' \


### PR DESCRIPTION
Fixes this error : 
`An error occurred (MalformedPolicyDocument) when calling the PutRolePolicy operation: The policy failed legacy parsing` when creating IAM permmision policy.
Error was made because when put-role-policy works, Resource's AWS ID is not IAM User's userID, it should be aws Account's ID.

This fixes the error, and works fine for me.