### PR TITLE
Set output of AWS_ID to text

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -122,7 +122,7 @@ ROLE_ARN=$(
     --query 'Role.Arn'
 )
 
-AWS_ID=$(aws sts get-caller-identity --query Account)
+AWS_ID=$(aws sts get-caller-identity --query Account --output text)
 
 aws iam put-role-policy \
   --role-name "$PROJECT_NAME" \


### PR DESCRIPTION
output을 지정하지 않아 기본 output이 json 등으로 설정된 환경에서 정상적으로 동작하지 않는 문제를 해결했습니다.